### PR TITLE
Updated Docker Image

### DIFF
--- a/coffee-shop/Dockerfile
+++ b/coffee-shop/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk16-openj9:x86_64-alpine-jre-16.0.1_9_openj9-0.26.0
+FROM adoptopenjdk/openjdk16-openj9
 RUN apk add curl
 
 COPY target/quarkus-app/lib/ /deployments/lib/


### PR DESCRIPTION
changed to use the following image 'adoptopenjdk/openjdk16-openj9'